### PR TITLE
feat(diagnostics)!: removed diagnostic setting retention policy

### DIFF
--- a/audit-variables.tf
+++ b/audit-variables.tf
@@ -49,10 +49,6 @@ variable "diagnostic_setting_log_categories" {
   description = "A list of log categories to be set for this diagnostic setting."
   type = list(object({
     category : string
-    retention_policy : optional(object({
-      enabled : optional(bool, true)
-      days : optional(string, 0)
-    }), {})
   }))
 
   default = [
@@ -71,10 +67,6 @@ variable "diagnostic_setting_metric_categories" {
   description = "A list of metric categories to be set for this diagnostic setting."
   type = list(object({
     category : string
-    retention_policy : optional(object({
-      enabled : optional(bool, true)
-      days : optional(string, 0)
-    }), {})
   }))
 
   default = [

--- a/audit.tf
+++ b/audit.tf
@@ -65,28 +65,13 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     for_each = toset(var.diagnostic_setting_log_categories)
     content {
       category = enabled_log.value.category
-      dynamic "retention_policy" {
-        for_each = [lookup(enabled_log.value, "retention_policy", null)]
-
-        content {
-          enabled = retention_policy.value.enabled
-          days    = lookup(retention_policy.value, "days", 0)
-        }
-      }
     }
   }
   dynamic "metric" {
     for_each = toset(var.diagnostic_setting_metric_categories)
     content {
       category = metric.value.category
-      dynamic "retention_policy" {
-        for_each = [lookup(metric.value, "retention_policy", null)]
 
-        content {
-          enabled = retention_policy.value.enabled
-          days    = lookup(retention_policy.value, "days", 0)
-        }
-      }
     }
   }
 }

--- a/audit.tf
+++ b/audit.tf
@@ -71,7 +71,6 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     for_each = toset(var.diagnostic_setting_metric_categories)
     content {
       category = metric.value.category
-
     }
   }
 }


### PR DESCRIPTION
Retention policy in `azurerm_monitor_diagnostic_setting` has been deprecated in favour of `azurerm_storage_management_policy`.
Ref [terraform azurerm_monitor_diagnostic_setting documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting)
![image](https://github.com/equinor/terraform-azurerm-synapse/assets/90191126/28b63259-4869-4d12-8349-63368d6a6da3)

Currently in our team we are not using retention policy, so I have not implemented this functionality in the module. The main reason for this change for us is to get rid of the deprecated warning in terraform plan.

For projects that need this functionality they can either create a PR to implement it, or create a resource outside of this module.